### PR TITLE
Add retry failed CI jobs twice

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,11 @@
+default:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
+
 stages:
   - lint
   - test


### PR DESCRIPTION
This PR add pipeline functionality to retry CI jobs twice in case if it failed due to following reasons: 
```
      - runner_system_failure
      - unknown_failure
      - api_failure
```